### PR TITLE
Fix project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,18 +42,18 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastapi>=0.68.0",
+    "fastapi>=0.120.1",
     "uvicorn>=0.15.0",
-    "python-multipart>=0.0.5",
+    "python-multipart>=0.0.22",
     "pywebview>=4.0.0",
     "cachetools>=4.2.0",
-    "pandas>=1.3.0",
-    "numpy>=1.20.0",
+    "pandas>=1.3.4",
+    "numpy>=1.22.0",
     "plotly>=5.0.0",
     "matplotlib>=3.4.0",
-    "jinja2>=3.0.0",
+    "jinja2>=3.1.6",
     "websockets>=10.0",
-    "bcrypt>=4.0.0"
+    "bcrypt>=4.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Updates Project dependencies

- `pandas`: `1.3.0` → `1.3.4`
  - fix incompatible lowest version
- `numpy`: `1.20.0` → `1.22.0`
  - fix incompatible lowest version
  - fix vulnerability
- `fastapi`: `0.68.0` → `0.120.1`
  - fix transitive vulnerability
- `python-multipart`: `0.0.5` → `0.0.22`
  - fix vulnerability
- `jinja2`: `3.0.0` → `3.1.6`
  - fix vulnerability

Fixes #4 